### PR TITLE
Fixing type issue

### DIFF
--- a/hdidx/encoder/sh.py
+++ b/hdidx/encoder/sh.py
@@ -50,8 +50,8 @@ class SHEncoder(Encoder):
 
         # 3) enumerate eigenfunctions
         R = mx - mn
-        maxMode = np.ceil((nbits+1) * R / R.max())
-        nModes = maxMode.sum() - maxMode.size + 1
+        maxMode = (np.ceil((nbits+1) * R / R.max())).astype(int)
+        nModes = int(maxMode.sum() - maxMode.size + 1)
         modes = np.ones((nModes, npca))
         m = 0
         for i in xrange(npca):

--- a/hdidx/encoder/sh.py
+++ b/hdidx/encoder/sh.py
@@ -51,7 +51,7 @@ class SHEncoder(Encoder):
         # 3) enumerate eigenfunctions
         R = mx - mn
         maxMode = (np.ceil((nbits+1) * R / R.max())).astype(int)
-        nModes = int(maxMode.sum() - maxMode.size + 1)
+        nModes = maxMode.sum() - maxMode.size + 1
         modes = np.ones((nModes, npca))
         m = 0
         for i in xrange(npca):


### PR DESCRIPTION
Noticed an issue with `np.ones` being given a `float` instead of an `int`